### PR TITLE
feat: add triangle latency summand

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,19 +56,23 @@ usage: speedbump [<flags>] <destination>
 TCP proxy for simulating variable network latency.
 
 Flags:
-  --help                Show context-sensitive help (also try --help-long and --help-man).
-  --port=8000           Port number to listen on.
-  --buffer=64KB         Size of the buffer used for TCP reads.
-  --queue-size=1024     Size of the delay queue storing read buffers.
-  --latency=5ms         Base latency added to proxied traffic.
-  --log-level=INFO      Log level. Possible values: DEBUG, TRACE, INFO, WARN, ERROR.
-  --sine-amplitude=0    Amplitude of the latency sine wave.
-  --sine-period=0       Period of the latency sine wave.
-  --saw-amplitude=0     Amplitude of the latency sawtooth wave.
-  --saw-period=0        Period of the latency sawtooth wave.
-  --square-amplitude=0  Amplitude of the latency square wave.
-  --square-period=0     Period of the latency square wave.
-  --version             Show application version.
+  --help                  Show context-sensitive help (also try --help-long and
+                          --help-man).
+  --port=8000             Port number to listen on.
+  --buffer=64KB           Size of the buffer used for TCP reads.
+  --queue-size=1024       Size of the delay queue storing read buffers.
+  --latency=5ms           Base latency added to proxied traffic.
+  --log-level=INFO        Log level. Possible values: DEBUG, TRACE, INFO, WARN,
+                          ERROR.
+  --sine-amplitude=0      Amplitude of the latency sine wave.
+  --sine-period=0         Period of the latency sine wave.
+  --saw-amplitude=0       Amplitude of the latency sawtooth wave.
+  --saw-period=0          Period of the latency sawtooth wave.
+  --square-amplitude=0    Amplitude of the latency square wave.
+  --square-period=0       Period of the latency square wave.
+  --triangle-amplitude=0  Amplitude of the latency triangle wave.
+  --triangle-period=0     Period of the latency triangle wave.
+  --version               Show application version.
 
 Args:
   <destination>  TCP proxy destination in host:post format.

--- a/args.go
+++ b/args.go
@@ -37,7 +37,13 @@ func parseArgs(args []string) (*lib.SpeedbumpCfg, error) {
 		squareAmplitude = app.Flag("square-amplitude", "Amplitude of the latency square wave.").
 				PlaceHolder("0").
 				Duration()
-		suqarePeriod = app.Flag("square-period", "Period of the latency square wave.").
+		squarePeriod = app.Flag("square-period", "Period of the latency square wave.").
+				PlaceHolder("0").
+				Duration()
+		triangleAmplitude = app.Flag("triangle-amplitude", "Amplitude of the latency triangle wave.").
+					PlaceHolder("0").
+					Duration()
+		trianglePeriod = app.Flag("triangle-period", "Period of the latency triangle wave.").
 				PlaceHolder("0").
 				Duration()
 		destAddr = app.Arg("destination", "TCP proxy destination in host:post format.").
@@ -58,13 +64,15 @@ func parseArgs(args []string) (*lib.SpeedbumpCfg, error) {
 		BufferSize: int(*bufferSize),
 		QueueSize:  *queueSize,
 		Latency: &lib.LatencyCfg{
-			Base:            *latency,
-			SineAmplitude:   *sineAmplitude,
-			SinePeriod:      *sinePeriod,
-			SawAmplitute:    *sawAmplitute,
-			SawPeriod:       *sawPeriod,
-			SquareAmplitude: *squareAmplitude,
-			SquarePeriod:    *suqarePeriod,
+			Base:              *latency,
+			SineAmplitude:     *sineAmplitude,
+			SinePeriod:        *sinePeriod,
+			SawAmplitute:      *sawAmplitute,
+			SawPeriod:         *sawPeriod,
+			SquareAmplitude:   *squareAmplitude,
+			SquarePeriod:      *squarePeriod,
+			TriangleAmplitude: *triangleAmplitude,
+			TrianglePeriod:    *trianglePeriod,
 		},
 		LogLevel: *logLevel,
 	}

--- a/args.go
+++ b/args.go
@@ -28,7 +28,7 @@ func parseArgs(args []string) (*lib.SpeedbumpCfg, error) {
 		sinePeriod = app.Flag("sine-period", "Period of the latency sine wave.").
 				PlaceHolder("0").
 				Duration()
-		sawAmplitute = app.Flag("saw-amplitude", "Amplitude of the latency sawtooth wave.").
+		SawAmplitude = app.Flag("saw-amplitude", "Amplitude of the latency sawtooth wave.").
 				PlaceHolder("0").
 				Duration()
 		sawPeriod = app.Flag("saw-period", "Period of the latency sawtooth wave.").
@@ -67,7 +67,7 @@ func parseArgs(args []string) (*lib.SpeedbumpCfg, error) {
 			Base:              *latency,
 			SineAmplitude:     *sineAmplitude,
 			SinePeriod:        *sinePeriod,
-			SawAmplitute:      *sawAmplitute,
+			SawAmplitude:      *SawAmplitude,
 			SawPeriod:         *sawPeriod,
 			SquareAmplitude:   *squareAmplitude,
 			SquarePeriod:      *squarePeriod,

--- a/args.go
+++ b/args.go
@@ -28,7 +28,7 @@ func parseArgs(args []string) (*lib.SpeedbumpCfg, error) {
 		sinePeriod = app.Flag("sine-period", "Period of the latency sine wave.").
 				PlaceHolder("0").
 				Duration()
-		SawAmplitude = app.Flag("saw-amplitude", "Amplitude of the latency sawtooth wave.").
+		sawAmplitude = app.Flag("saw-amplitude", "Amplitude of the latency sawtooth wave.").
 				PlaceHolder("0").
 				Duration()
 		sawPeriod = app.Flag("saw-period", "Period of the latency sawtooth wave.").
@@ -67,7 +67,7 @@ func parseArgs(args []string) (*lib.SpeedbumpCfg, error) {
 			Base:              *latency,
 			SineAmplitude:     *sineAmplitude,
 			SinePeriod:        *sinePeriod,
-			SawAmplitude:      *SawAmplitude,
+			SawAmplitude:      *sawAmplitude,
 			SawPeriod:         *sawPeriod,
 			SquareAmplitude:   *squareAmplitude,
 			SquarePeriod:      *squarePeriod,

--- a/args_test.go
+++ b/args_test.go
@@ -32,6 +32,8 @@ func TestParseArgsAll(t *testing.T) {
 			"--sine-period=1m",
 			"--square-amplitude=123ms",
 			"--square-period=3m",
+			"--triangle-amplitude=150ms",
+			"--triangle-period=2m",
 			"host:777",
 		},
 	)
@@ -46,4 +48,6 @@ func TestParseArgsAll(t *testing.T) {
 	assert.Equal(t, time.Duration(0), cfg.Latency.SawPeriod)
 	assert.Equal(t, time.Millisecond*123, cfg.Latency.SquareAmplitude)
 	assert.Equal(t, time.Minute*3, cfg.Latency.SquarePeriod)
+	assert.Equal(t, time.Millisecond*150, cfg.Latency.TriangleAmplitude)
+	assert.Equal(t, time.Minute*2, cfg.Latency.TrianglePeriod)
 }

--- a/args_test.go
+++ b/args_test.go
@@ -44,7 +44,7 @@ func TestParseArgsAll(t *testing.T) {
 	assert.Equal(t, time.Millisecond*100, cfg.Latency.Base)
 	assert.Equal(t, time.Millisecond*50, cfg.Latency.SineAmplitude)
 	assert.Equal(t, time.Minute, cfg.Latency.SinePeriod)
-	assert.Equal(t, time.Duration(0), cfg.Latency.SawAmplitute)
+	assert.Equal(t, time.Duration(0), cfg.Latency.SawAmplitude)
 	assert.Equal(t, time.Duration(0), cfg.Latency.SawPeriod)
 	assert.Equal(t, time.Millisecond*123, cfg.Latency.SquareAmplitude)
 	assert.Equal(t, time.Minute*3, cfg.Latency.SquarePeriod)

--- a/lib/latency_generator.go
+++ b/lib/latency_generator.go
@@ -9,13 +9,15 @@ type LatencyGenerator interface {
 }
 
 type LatencyCfg struct {
-	Base            time.Duration
-	SineAmplitude   time.Duration
-	SinePeriod      time.Duration
-	SawAmplitute    time.Duration
-	SawPeriod       time.Duration
-	SquareAmplitude time.Duration
-	SquarePeriod    time.Duration
+	Base              time.Duration
+	SineAmplitude     time.Duration
+	SinePeriod        time.Duration
+	SawAmplitute      time.Duration
+	SawPeriod         time.Duration
+	SquareAmplitude   time.Duration
+	SquarePeriod      time.Duration
+	TriangleAmplitude time.Duration
+	TrianglePeriod    time.Duration
 }
 
 type latencySummand interface {
@@ -45,6 +47,12 @@ func newSimpleLatencyGenerator(start time.Time, cfg *LatencyCfg) simpleLatencyGe
 		summands = append(summands, squareLatencySummand{
 			cfg.SquareAmplitude,
 			cfg.SquarePeriod,
+		})
+	}
+	if cfg.TriangleAmplitude > 0 && cfg.TrianglePeriod > 0 {
+		summands = append(summands, triangleLatencySummand{
+			cfg.TriangleAmplitude,
+			cfg.TrianglePeriod,
 		})
 	}
 	return simpleLatencyGenerator{

--- a/lib/latency_generator.go
+++ b/lib/latency_generator.go
@@ -12,7 +12,7 @@ type LatencyCfg struct {
 	Base              time.Duration
 	SineAmplitude     time.Duration
 	SinePeriod        time.Duration
-	SawAmplitute      time.Duration
+	SawAmplitude      time.Duration
 	SawPeriod         time.Duration
 	SquareAmplitude   time.Duration
 	SquarePeriod      time.Duration
@@ -37,9 +37,9 @@ func newSimpleLatencyGenerator(start time.Time, cfg *LatencyCfg) simpleLatencyGe
 			cfg.SinePeriod,
 		})
 	}
-	if cfg.SawAmplitute > 0 && cfg.SawPeriod > 0 {
+	if cfg.SawAmplitude > 0 && cfg.SawPeriod > 0 {
 		summands = append(summands, sawtoothLatencySummand{
-			cfg.SawAmplitute,
+			cfg.SawAmplitude,
 			cfg.SawPeriod,
 		})
 	}

--- a/lib/latency_generator_test.go
+++ b/lib/latency_generator_test.go
@@ -42,3 +42,23 @@ func TestSimpleLatencyGeneratorWithSawtooth(t *testing.T) {
 	assert.Equal(t, time.Second*1, after4Sec)
 	assert.Equal(t, time.Second*3, after2Periods)
 }
+
+func TestSimpleLatencyGeneratorWithTriangle(t *testing.T) {
+	start := time.Now()
+	g := newSimpleLatencyGenerator(start, &LatencyCfg{
+		Base:              time.Second * 3,
+		TriangleAmplitude: time.Second * 2,
+		TrianglePeriod:    time.Second * 8,
+	})
+
+	startingVal := g.generateLatency(start)
+	after2Sec := g.generateLatency(start.Add(time.Second * 2))
+	after4Sec := g.generateLatency(start.Add(time.Second * 4))
+	after6Sec := g.generateLatency(start.Add(time.Second * 6))
+	after2Periods := g.generateLatency(start.Add(time.Second * 16))
+	assert.Equal(t, time.Second*3, startingVal)
+	assert.Equal(t, time.Second*5, after2Sec)
+	assert.Equal(t, time.Second*3, after4Sec)
+	assert.Equal(t, time.Second*1, after6Sec)
+	assert.Equal(t, time.Second*3, after2Periods)
+}

--- a/lib/latency_generator_test.go
+++ b/lib/latency_generator_test.go
@@ -29,7 +29,7 @@ func TestSimpleLatencyGeneratorWithSawtooth(t *testing.T) {
 	start := time.Now()
 	g := newSimpleLatencyGenerator(start, &LatencyCfg{
 		Base:         time.Second * 3,
-		SawAmplitute: time.Second * 2,
+		SawAmplitude: time.Second * 2,
 		SawPeriod:    time.Second * 8,
 	})
 

--- a/lib/sawtooth_test.go
+++ b/lib/sawtooth_test.go
@@ -13,9 +13,9 @@ func TestSawtoothLatencySummand(t *testing.T) {
 		period:    time.Minute,
 	}
 
-	assert.Equal(t, s.getLatency(time.Duration(0)), time.Millisecond*0)
-	assert.Equal(t, s.getLatency(time.Second*15), time.Millisecond*500)
-	assert.Equal(t, s.getLatency(time.Second*30), time.Millisecond*-1000)
-	assert.Equal(t, s.getLatency(time.Second*36), time.Millisecond*-800)
-	assert.Equal(t, s.getLatency(time.Second*60), time.Millisecond*0)
+	assert.Equal(t, time.Millisecond*0, s.getLatency(time.Duration(0)))
+	assert.Equal(t, time.Millisecond*500, s.getLatency(time.Second*15))
+	assert.Equal(t, time.Millisecond*-1000, s.getLatency(time.Second*30))
+	assert.Equal(t, time.Millisecond*-800, s.getLatency(time.Second*36))
+	assert.Equal(t, time.Millisecond*0, s.getLatency(time.Second*60))
 }

--- a/lib/triangle.go
+++ b/lib/triangle.go
@@ -1,0 +1,16 @@
+package lib
+
+import (
+	"math"
+	"time"
+)
+
+type triangleLatencySummand struct {
+	amplitude time.Duration
+	period    time.Duration
+}
+
+func (t triangleLatencySummand) getLatency(elapsed time.Duration) time.Duration {
+	a, p, x := float64(t.amplitude), float64(t.period), float64(elapsed)
+	return time.Duration(4*a/p*math.Abs(math.Mod(((math.Mod((x-p/4), p))+p), p)-p/2) - a)
+}

--- a/lib/triangle_test.go
+++ b/lib/triangle_test.go
@@ -1,0 +1,25 @@
+package lib
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTriangleLatencySummand(t *testing.T) {
+	s := triangleLatencySummand{
+		amplitude: time.Second,
+		period:    time.Minute,
+	}
+
+	assert.Equal(t, time.Millisecond*0, s.getLatency(time.Duration(0)))
+	assert.Equal(t, time.Millisecond*500, s.getLatency(time.Millisecond*7500))
+	assert.Equal(t, time.Millisecond*1000, s.getLatency(time.Millisecond*15000))
+	assert.Equal(t, time.Millisecond*500, s.getLatency(time.Millisecond*22500))
+	assert.Equal(t, time.Millisecond*0, s.getLatency(time.Millisecond*30000))
+	assert.Equal(t, -time.Millisecond*500, s.getLatency(time.Millisecond*37500))
+	assert.Equal(t, -time.Millisecond*1000, s.getLatency(time.Millisecond*45000))
+	assert.Equal(t, -time.Millisecond*500, s.getLatency(time.Millisecond*52500))
+	assert.Equal(t, time.Millisecond*0, s.getLatency(time.Millisecond*60000))
+}


### PR DESCRIPTION
What was done in this PR:
- Added triangle summands. 

Additionally:
- Adjusted the order of passing args to some assertions to match naming from https://pkg.go.dev/github.com/stretchr/testify/assert#Equal (`expected` is passed first, and `actual` value is the last arg)
- Fixed typo `sawAmplitute` -> `sawAmplitude`

Resolves #19