### PR TITLE
feat!: `lib` API improvements

### DIFF
--- a/args.go
+++ b/args.go
@@ -51,7 +51,7 @@ func parseArgs(args []string) (*lib.SpeedbumpCfg, error) {
 				String()
 	)
 
-	app.Version("0.2.0")
+	app.Version("1.0.0")
 	_, err := app.Parse(args)
 
 	if err != nil {

--- a/lib/README.md
+++ b/lib/README.md
@@ -28,13 +28,13 @@ func main() {
 		Port:       8000,
 		DestAddr:   "localhost:80",
 		BufferSize: 16384,
-		QueueSize: 2048,
+		QueueSize:  2048,
 		Latency: &speedbump.LatencyCfg{
 			Base:          time.Millisecond * 100,
 			SineAmplitude: time.Millisecond * 50,
 			SinePeriod:    time.Minute,
 		},
-		LogLevel: "INFO",
+		LogLevel: "TRACE",
 	}
 
 	s, err := speedbump.NewSpeedbump(&cfg)
@@ -44,14 +44,8 @@ func main() {
 		return
 	}
 
-	go func() {
-		// stop the proxy after 5 minutes
-		time.Sleep(time.Second * 5)
-		s.Stop()
-	}()
-
-	// Start() will either block until .Stop() is called
-	// or return immedietely if there is a startup error
+	// Start() will unblock as soon as the proxy is started
+	// or return an error if there is a startup error
 	err = s.Start()
 
 	if err != nil {
@@ -59,7 +53,20 @@ func main() {
 		return
 	}
 
+	// let's stop the proxy after 5 mins
+	time.Sleep(time.Minute * 5)
+
+	s.Stop()
+
 	// DONE
 }
+
 ```
 
+## `v1` Upgrade guide
+
+In an effort to make the `lib` package easier to work with when used as a dependency for Go tests, the following changes were made to its API in the `v1` release:
+
+- `Start()` is no longer blocking. It will either unblock as soon as the proxy starts listening or return an error if proxy startup fails;
+- `Stop()` waits for all proxy connections to close before returning;
+- a field name typo `sawAmplitute` was fixed in `LatencyCfg` struct (renamed to `SawAmplitude`).

--- a/lib/speedbump_test.go
+++ b/lib/speedbump_test.go
@@ -135,24 +135,15 @@ func TestSpeedbumpWithEchoServer(t *testing.T) {
 		"WARN",
 	}
 	s, err := NewSpeedbump(&cfg)
-	go s.Start()
+	s.Start()
 
 	assert.Nil(t, err)
 
 	tcpAddr, _ := net.ResolveTCPAddr("tcp", "localhost:8000")
 
-	var conn *net.TCPConn
-
-	// Wait for the speedbump instance to start listening
-	// since it is started in a separate goroutine, we don't know
-	// if it has already started listening by this point
-	for {
-		conn, err = net.DialTCP("tcp", nil, tcpAddr)
-		if err != nil {
-			time.Sleep(10 * time.Millisecond)
-		} else {
-			break
-		}
+	conn, err := net.DialTCP("tcp", nil, tcpAddr)
+	if err != nil {
+		panic(err)
 	}
 
 	firstOpStart := time.Now()

--- a/main.go
+++ b/main.go
@@ -30,10 +30,19 @@ func main() {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
+	done := make(chan bool)
+
 	go func() {
 		<-sigs
-		go s.Stop()
+		// signal was caught for the first time
+		// stop the speedbump instance
+		go func() {
+			s.Stop()
+			done <- true
+		}()
 		<-sigs
+		// signal was caught for the second time
+		// force the process to exit
 		os.Exit(1)
 	}()
 
@@ -42,4 +51,6 @@ func main() {
 	if err != nil {
 		exitWithError(err)
 	}
+
+	<-done
 }


### PR DESCRIPTION
This PR implements `lib` API improvements as described in #20.

Changes made to the `lib` API:

- `Start()` is no longer blocking. It will either unblock as soon as the proxy starts listening or return an error if proxy startup fails;
- `Stop()` waits for all proxy connections to close before returning.

Resolves #20 